### PR TITLE
Add author email to pyproject.toml

### DIFF
--- a/software/pyproject.toml
+++ b/software/pyproject.toml
@@ -3,7 +3,7 @@ name = "obi"
 version = "0"
 description = "Electron microscope image capture with Glasgow and Open Beam Interface hardware"
 authors = [
-    {name = "nanographs"},
+    {name = "nanographs", email = "adam@nanographs.io"},
     {name = "isabelburgos", email = "isabel@nanographs.io"},
 ]
 dependencies = [


### PR DESCRIPTION
Addresses #9 , where an install resulting in the error `ValueError: invalid pyproject.toml config: `project.authors[0].email`.`