### PR TITLE
gui.components.file_io: handle directory path correctly

### DIFF
--- a/software/obi/gui/components/file_io.py
+++ b/software/obi/gui/components/file_io.py
@@ -30,5 +30,5 @@ class BrowseDirectory(QVBoxLayout):
         path = QFileDialog.getExistingDirectory()
         if not path:
             return
-        self.path_str = path[0]
+        self.path_str = path
         self.path_box.setText(path)


### PR DESCRIPTION
Previously, I was handling the output of QFileDialog().getExistingDIrectory() as if it were a tuple, but it's actually just a string.
This is probably due to me reusing code at some point, and switching between a file selection dialog and a directory selection dialog.
Compare these two signatures:
```python
path = QFileDialog().getExistingDirectory() #directory selection
path, _ = QFileDialog().getOpenFileName() #file selection
```