### PR TITLE
gui.components.scan_parameters: check custom fields non-empty

### DIFF
--- a/software/obi/gui/components/scan_parameters.py
+++ b/software/obi/gui/components/scan_parameters.py
@@ -48,11 +48,16 @@ class SettingBoxWithDefaults(QHBoxLayout):
         self.addWidget(self.label)
         self.addWidget(self.dropdown)
         self.addWidget(self.spinbox)
+
+        self.last_custom_val = initial_val
     
     def getval(self) -> int:
         val = self.dropdown.currentText()
         if val == "Custom":
-            return int(self.spinbox.cleanText())
+            custom_field = self.spinbox.cleanText()
+            if custom_field != "":
+                self.last_custom_val = int(custom_field)
+            return self.last_custom_val
         else:
             return int(val)
 


### PR DESCRIPTION
This fixes a failure mode where if you selected "Custom" in the dwell time or resolution drop-downs, and then backspaced in the field that appears for you to input custom values, the GUI would crash.
The "Custom" field is a QSpinBox that is already constrained to only contain integers that are within the range of acceptable dwell time/resolution values. However, the one other thing it can temporarily contain is nothing: `""`.
To patch this, I keep track of the last value that was entered in the custom field and use that for the resolution/dwell time parameter until the next non-`""` value is input.

## Looking ahead:
I think the implementation of a custom field that changes a live parameter is clunky and should be replaced with a different UX. For example, if you type `2000` in the resolution field, it will interpret that as `2`, then `20`, then `200`, then `2000`.  On the other hand, scrolling through resolution values with the live-updating spinbox, while the frame size changes dynamically, feels very smooth. [PyQtGraph has a customized spinbox component](https://pyqtgraph.readthedocs.io/en/latest/api_reference/widgets/spinbox.html) that filters out rapid changes, we could drop that in instead.