### PR TITLE
Introduce kibot to the main branch

### DIFF
--- a/.github/workflows/kibot/kibot.yml
+++ b/.github/workflows/kibot/kibot.yml
@@ -1,0 +1,26 @@
+kibot:
+  version: 1
+
+outputs:
+  - name: 'ibom'
+    comment: 'Interactive Bill of Materials'
+    type: ibom
+    dir: .
+    options:
+      layer-view: 'F'
+      dark-mode: true
+
+  - name: 'bom'
+    comment: 'Bill of Materials'
+    type: bom
+    dir: .
+    options:
+      csv:
+        hide_pcb_info: true
+        hide_stats_info: true
+      format: CSV
+
+  - name: 'print_sch'
+    comment: "Print schematic (PDF)"
+    type: pdf_sch_print
+    dir: .

--- a/.github/workflows/kicad.yml
+++ b/.github/workflows/kicad.yml
@@ -1,0 +1,96 @@
+name: Export KiCad
+on:
+  workflow_dispatch:
+  push:
+      paths:
+      - '**.sch'
+      - '**.kicad_pcb'
+      - '.github/workflows/kicad.yml' # Trigger on changes to the workflow file
+      - '**.kibot.yml' # Trigger on changes to the KiBot config file used in the workflow
+  
+jobs:
+  export-ecad:
+    name: Export ECAD
+    runs-on: ubuntu-latest
+    container: ghcr.io/inti-cmnb/kicad8_auto
+    permissions:
+      contents: write
+      pull-requests: write
+      
+    steps:
+    - name: Update system repositories, Install Required Libraries and Initialize git-lfs
+      run: |
+        apt update
+        apt -y install git git-lfs zip librsvg2-bin imagemagick
+        git lfs install
+
+    - name: Checkout Repository
+      uses: actions/checkout@v2
+      with:
+        lfs: true
+
+    ## Main OBI board
+    - name: Generate Export Files
+      run: |
+        cd "Hardware/PCBs/Open Beam Interface"
+        kibot -c ../../../.github/workflows/kibot/kibot.yml -e "Open Beam Interface.kicad_sch" -b "Open Beam Interface.kicad_pcb"
+
+    - name: Generate Export Files
+      run: |
+        cd "Hardware/PCBs/Data Interconnect"
+        kibot -c ../../../.github/workflows/kibot/kibot.yml -e "OBI Data Interconnect.kicad_sch" -b "OBI Data Interconnect.kicad_pcb"
+
+    - name: Generate Export Files
+      run: |
+        cd "Hardware/PCBs/Digital IO Breakout/revA1/Digital IO Breakout"
+        kibot -c ../../../../../.github/workflows/kibot/kibot.yml -e "Digital IO Breakout.kicad_sch" -b "Digital IO Breakout.kicad_pcb"
+
+    ## Interface selectors and drivers
+    - name: Generate Export Files
+      run: |
+        cd "Hardware/PCBs/Interface selectors and drivers/Beam Offset Switch"
+        kibot -c ../../../../.github/workflows/kibot/kibot.yml -e "Beam Offset Switch.kicad_sch" -b "Beam Offset Switch.kicad_pcb"
+
+    - name: Generate Export Files
+      run: |
+        cd "Hardware/PCBs/Interface selectors and drivers/DB9 Differential Signal Selector"
+        kibot -c ../../../../.github/workflows/kibot/kibot.yml -e "DB9 Differential Signal Selector.kicad_sch" -b "DB9 Differential Signal Selector.kicad_pcb"
+
+    - name: Generate Export Files
+      run: |
+        cd "Hardware/PCBs/Interface selectors and drivers/DB9 High-Low Signal Generator"
+        kibot -c ../../../../.github/workflows/kibot/kibot.yml -e "DB9 High-Low Signal Generator.kicad_sch" -b "DB9 High-Low Signal Generator.kicad_pcb"
+
+    - name: Generate Export Files
+      run: |
+        cd "Hardware/PCBs/Interface selectors and drivers/DSC DB9 Splitter"
+        kibot -c ../../../../.github/workflows/kibot/kibot.yml -e "DSC DB9 Splitter.kicad_sch" -b "DSC DB9 Splitter.kicad_pcb"
+
+    - name: Generate Export Files
+      run: |
+        cd "Hardware/PCBs/Interface selectors and drivers/DSC Scan Selector"
+        kibot -c ../../../../.github/workflows/kibot/kibot.yml -e "DSC Scan Selector.kicad_sch" -b "DSC Scan Selector.kicad_pcb"
+
+    - name: Generate Export Files
+      run: |
+        cd "Hardware/PCBs/Interface selectors and drivers/Generic Scan Selector"
+        kibot -c ../../../../.github/workflows/kibot/kibot.yml -e "Generic Scan Selector.kicad_sch" -b "Generic Scan Selector.kicad_pcb"
+
+    - name: Create Pull Request
+      id: cpr
+      uses: peter-evans/create-pull-request@v7
+      with:
+        commit-message: 🤖 kibot generated 🤖
+        committer: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
+        author: 🤖 <isabel@nanographs.io>
+        signoff: false
+        branch: kibot-auto
+        delete-branch: true
+        title: 'Generated Kicad Files'
+        body: |
+          *beep* your files are done!
+        labels: |
+          report
+          automated pr
+
+        


### PR DESCRIPTION
This workflow automatically generates the following outputs whenever KiCAD files are edited:
- CSV BOM
- Interactive HTML BOM
- Schematic PDF
Then, the workflow generates a pull request with the generated changes, which can only be merged by a human (not automatically).

That way, we don't have to worry about keeping these files up to date with the KiCAD design files. The `.kicad_pcb` and `kicad_sch` files should be the source of truth, and the other output files should be regenerated every time those are changed.