### PR TITLE
Replace running average with a true-er average

### DIFF
--- a/software/obi/gui/components/scan_parameters.py
+++ b/software/obi/gui/components/scan_parameters.py
@@ -79,7 +79,7 @@ class ScanParameters(QVBoxLayout):
         self.addLayout(self.dwell_time)
     def getval(self) -> int:
         resolution = self.resolution_settings.getval()
-        dwell = self.dwell_time.getval()
+        dwell = self.dwell_time.getval() - 1
         return resolution, dwell
 
 class LiveScanControls(ScanParameters):

--- a/software/tests/gateware/test_open_beam_interface.py
+++ b/software/tests/gateware/test_open_beam_interface.py
@@ -133,8 +133,12 @@ class OBIAppletTestCase(unittest.TestCase):
         sim.add_clock(20.83e-9)
         for testbench in testbenches:
             sim.add_testbench(testbench)
-        with sim.write_vcd(f"{name}.vcd"), sim.write_vcd(f"{name}+d.vcd", fs_per_delta=250_000):
+        try:
             sim.run()
+        except:
+            sim.reset()
+            with sim.write_vcd(f"{name}.vcd"), sim.write_vcd(f"{name}+d.vcd", fs_per_delta=250_000):
+                sim.run()
 
     ## Bus Controller
     def test_bus_controller_streams(self):

--- a/software/tests/gateware/test_open_beam_interface.py
+++ b/software/tests/gateware/test_open_beam_interface.py
@@ -7,6 +7,7 @@ from amaranth import DriverConflict
 from amaranth.lib import wiring
 from abc import ABCMeta, abstractmethod
 import asyncio
+import numpy as np
 
 from .board_sim import OBI_Board
 
@@ -14,7 +15,7 @@ import logging
 logger = logging.getLogger()
 
 from obi.applet.open_beam_interface import StreamSignature
-from obi.applet.open_beam_interface import Supersampler, RasterScanner, RasterRegion
+from obi.applet.open_beam_interface import Supersampler, PowerOfTwoDetector, RasterScanner, RasterRegion
 from obi.applet.open_beam_interface import CommandParser, CommandExecutor, Command, BeamType, OutputMode, CmdType
 from obi.applet.open_beam_interface import BusController
 from obi.commands import *
@@ -271,6 +272,61 @@ class OBIAppletTestCase(unittest.TestCase):
 
         self.simulate(dut, [put_testbench, get_testbench], name = "ss_avg2")
     
+    def test_p2_detector(self):
+        dut = PowerOfTwoDetector(4)
+        def testcase(i, o_exp, p_exp):
+            async def testbench(ctx):
+                ctx.set(dut.i, i)
+                o = ctx.get(dut.o)
+                p = ctx.get(dut.p)
+                assert (o,p) == (o_exp, p_exp), f"input: {i}, expected: o={o_exp}, p={p_exp}, actual: {o=}, {p=}"
+
+            sim = Simulator(dut)
+            sim.add_testbench(testbench)
+            sim.run()
+        
+        testcase(1, 0, 1)
+        testcase(2, 1, 1)
+        testcase(3, 1, 0)
+        testcase(4, 2, 1)
+        testcase(6, 2, 0)
+        testcase(8, 3, 1)
+
+    def test_supersampler_average_rand(self):
+        def check_avg_random_samples(nvals:int):
+            dut = Supersampler()
+            vals = np.random.randint(0,16383, nvals)
+
+            async def put_testbench(ctx):
+                ctx.set(dut.dac_stream_data.dwell_time, nvals)
+                for n in range(len(vals)):
+                    last = 0
+                    if n + 1 == len(vals):
+                        last = 1
+                    await put_stream(ctx, dut.super_adc_stream,
+                        {"adc_code": vals[n], "adc_ovf": 0, "last": last})
+                await put_stream(ctx, dut.super_adc_stream,
+                    {"adc_code": 999, "adc_ovf": 0, "last": 0})
+
+            def get_closest_p2(n):
+                i = 1
+                while pow(2,i) < n:
+                    i += 1
+                if n != pow(2,i):
+                    i -= 1
+                return max(1, pow(2,i))
+
+            async def get_testbench(ctx):
+                closest_p2 = get_closest_p2(nvals)
+                print(f"for {nvals} values, average first {closest_p2}")
+                await get_stream(ctx, dut.adc_stream,
+                    {"adc_code": (sum(list(vals)[:closest_p2]))//closest_p2}, timeout_steps = nvals*3)
+                assert ctx.get(dut.adc_stream.valid) == 0
+
+            self.simulate(dut, [put_testbench, get_testbench], name = f"ss_avg_rand_{nvals}")
+        
+        for n in [1,2,4,5,8,16,24, 32,64,128]:
+            check_avg_random_samples(n)
     
     # Raster Scanner
     def test_raster_scanner(self):

--- a/software/tests/gateware/test_open_beam_interface.py
+++ b/software/tests/gateware/test_open_beam_interface.py
@@ -2,10 +2,13 @@ import unittest
 import struct
 import array
 from amaranth.sim import Simulator, Tick
-from amaranth import Signal, ShapeCastable, Const
+from amaranth import *
 from amaranth import DriverConflict
+from amaranth.lib import wiring
 from abc import ABCMeta, abstractmethod
 import asyncio
+
+from .board_sim import OBI_Board
 
 import logging
 logger = logging.getLogger()
@@ -818,12 +821,12 @@ class OBIAppletTestCase(unittest.TestCase):
                             board.x_latch_chip.d.eq(obi_subtarget.data.o),
                             board.y_latch_chip.d.eq(obi_subtarget.data.o),
                             board.a_adc_chip.a.eq(board.x_dac_chip.a),
-                            board.x_latch.eq(obi_subtarget.control.x_latch.o),
-                            board.y_latch.eq(obi_subtarget.control.y_latch.o),
-                            board.a_latch.eq(obi_subtarget.control.a_latch.o),
-                            board.a_enable.eq(obi_subtarget.control.a_enable.o),
-                            board.a_clock.eq(obi_subtarget.control.a_clock.o),
-                            board.d_clock.eq(obi_subtarget.control.d_clock.o),
+                            board.bus.dac_x_le_clk.eq(obi_subtarget.control.x_latch.o),
+                            board.bus.dac_y_le_clk.eq(obi_subtarget.control.y_latch.o),
+                            board.bus.adc_le_clk.eq(obi_subtarget.control.a_latch.o),
+                            board.bus.adc_oe.eq(obi_subtarget.control.a_enable.o),
+                            board.bus.adc_clk.eq(obi_subtarget.control.a_clock.o),
+                            board.bus.dac_clk.eq(obi_subtarget.control.d_clock.o),
                             board.adc_input.eq(board.x_dac_chip.a)
                             ]
                 self.target.add_submodule(m)


### PR DESCRIPTION
The Open Beam Interface applet returns one intensity value per pixel in an image. The average ADC value for each pixel is computed in hardware. 
The "true" average of a collection of samples is the sum of those values, divided by the number of values:

> (sum of all n samples) / n

 However, it is not feasible to implement this arbitrary division at scan speed, on the iCE40 FPGA at least. 

## Prior work

Up to this point, we have made do with a "running average", like so:
> running average = (running average + new sample) / 2

Because the most recent sample is heavily weighted, this average is unfortunately noisy.

## Proposed Change

While arbitrary division is slow, dividing by powers of 2 is a simple bit shift. For powers of two, we can trivially implement perfect "true" averaging:
> number of samples = 2^n
> average = (sum of all n samples) >> n


To determine whether the number of samples is a power of 2, and how many `n` bits to shift by, we use something like a priority encoder/decoder. I gave this module the name `PowerOfTwoDetector` because that's what it does.
This algorithm has the unfortunate property of generating glitchy nonsense images for dwell times that aren't powers of two. That's bad!

The solution I've arrived at for making all dwell times generate sensible images is as follows: When the current number of summed samples is a power of two, register that sum as the "last power of two". When the final sample is received, if the total number of samples is not a power of two, the average of the "last power of two" samples is returned.
For a dwell time of 5, the first 4 samples are averaged. For a dwell time of 24, the first 16 samples are averaged.

## Drawbacks

For non-power of two dwell times, the average is imperfect and weighted towards the beginning of data collection. Having the average be weighted towards the end of the dwell time would be preferable for applications like FIB milling, where the surface of the sample is changing over time and the most recent samples reflect that. 

We could potentially keep the "running average" code and add a build argument to the applet. Having the implementation of hardware averaging be open and editable is one of the ways this project stands apart from closed source scan systems, and I like the idea of having several options included, but I'd rather ship this now than continue expanding the scope.

## Benefits

Compared to the current "running average" implementation, this method of averaging SUBSTANTIALLY improves image quality by reducing noise. The following images demonstrate this; the first image uses 4 averaged samples and the second image uses 32. 

![IMAGE 2025-02-08 19:41:51](https://github.com/user-attachments/assets/fb96dca9-3711-42d6-8523-1bf49f204cdd)
![IMAGE 2025-02-08 19:41:55](https://github.com/user-attachments/assets/9553b340-4bdf-455a-997d-2dce60d4ce6f)
