### PR TITLE
obi.launch: cancel non-overriden interface before using override

### DIFF
--- a/software/obi/launch.py
+++ b/software/obi/launch.py
@@ -13,6 +13,7 @@ class OBIDemux(glasgow_access.DirectDemultiplexer):
     async def claim_interface(self, applet, mux_interface, *args, **kwargs):
         iface = await super().claim_interface(applet, mux_interface, *args, **kwargs)
         self._interfaces.remove(iface)
+        await iface.cancel()
         new_iface = OBIDemuxInterface(self.device, applet, mux_interface, **kwargs)
         self._interfaces.append(new_iface)
         return new_iface


### PR DESCRIPTION
If we don't do this, the old tasks keep running and stealing data from the newly overridden interface. This manifests as timing-dependent FIFO RX data drops. In practice this meant that small image acquisition worked (because the receive path was being drained fast enough), but larger acquisitions didn't.

I have no idea how this ever worked - maybe OS, HW or load differences? I'm on Linux (6.6.85, NixOS), AMD64.