### PR TITLE
obi: fix pyproject for installation

### DIFF
--- a/software/obi/launch.py
+++ b/software/obi/launch.py
@@ -86,5 +86,8 @@ async def run_server():
     l = OBILauncher()
     await l.launch_server()
 
-if __name__ == "__main__":
+def main_server():
     asyncio.run(run_server())
+
+if __name__ == "__main__":
+    main_server()

--- a/software/pyproject.toml
+++ b/software/pyproject.toml
@@ -20,6 +20,9 @@ license = {text = "\"0BSD OR Apache-2.0\""}
 [project.entry-points."glasgow.applet"]
 open_beam_interface = "obi.applet.open_beam_interface:OBIApplet"
 
+[project.scripts]
+obi-server = "obi.launch:main_server"
+obi-gui = "obi.gui.main:run_gui"
 
 [project.optional-dependencies]
 "gui" = [
@@ -34,12 +37,10 @@ open_beam_interface = "obi.applet.open_beam_interface:OBIApplet"
     "enum-tools[sphinx]>=0.12.0",
     "sphinxcontrib-yowasp-wavedrom>=1.8",
 ]
+
 [build-system]
 requires = ["pdm-backend"]
 build-backend = "pdm.backend"
-
-[tool.pdm.build]
-includes = ["applet"]
 
 [tool.pdm.scripts]
 _.env = {GLASGOW_OUT_OF_TREE_APPLETS = "I-am-okay-with-breaking-changes"}
@@ -54,6 +55,7 @@ docs.cmd = "sphinx-build -M html docs/source/ docs/build/ -a"
 docs_serve.cmd = "python -m http.server -d docs/build/html"
 ## unit tests
 test.cmd = "python -m unittest"
+
 [tool.pdm.dev-dependencies]
 dev = [
     "rich>=13.7.1",


### PR DESCRIPTION
This fixes tarballs/wheels built by `pdm build` for anything that might need it (eg. Nix builds).

Two top-level executables/scripts are defined: obi-server and obi-gui. These become proper CLI commands that can be ran after the installation (vs. pdm scripts that have to be run through `pdm`).

The 'applet' include path is removed, it seems to be some kind of leftover that prevented any files from being installed into a distribution tarball (because this path is not additive, but replaces the default path inferred by pdm).