### PR TITLE
Align 14-bit ADC values to 16 bits in gateware

### DIFF
--- a/software/examples/vector_csv_acquisition.py
+++ b/software/examples/vector_csv_acquisition.py
@@ -1,0 +1,48 @@
+import asyncio
+import array
+import csv
+import itertools
+
+from obi.transfer import TCPConnection
+from obi.macros.vector import VectorScanCommand
+from obi.commands import OutputMode
+
+async def main():
+    # Open Connection
+    # TCP server must be running at this port
+    conn = TCPConnection('localhost', 2224)
+
+    # Convert a CSV file into an iterator that yields (x, y, dwell)
+    def iter_read_csv(path:str):
+        with open(path, newline='') as csvfile:
+            reader = csv.reader(csvfile, delimiter=',')
+            for row in reader:
+                x, y, dwell = [int(n) for n in row]
+                yield (x, y, dwell) #if the csv file contains characters, this breaks
+
+    # Iterate over the csv file twice - once when creating the vector commands, and again when writing the output
+    send_iter, recv_iter = itertools.tee(iter_read_csv("points.csv"))
+
+    # construct the vector scan command from an iterator that yields (x, y, dwell)
+    cmd = VectorScanCommand(cookie=123, output_mode=OutputMode.EightBit, iter_points=send_iter)
+    # convert vector commands into raw bytes
+    # point commands are divided into chunks when combined dwell time exceeds 65536
+    cmd._pre_process_chunks(latency=65536)
+
+    # acquire the data
+    res = array.array('B')
+    async for chunk in conn.transfer_multiple(cmd):
+        print(f"{chunk=}")
+        res.extend(chunk)
+    print(f"{res=}")
+
+    # save the data into another csv in the format x, y, brightness
+    with open("points_data.csv", 'w', newline='') as csvfile:
+        writer = csv.writer(csvfile, delimiter=',')
+        for (x, y, dwell), (brightness) in zip(recv_iter, iter(res)):
+            print(x, y, dwell, brightness)
+            writer.writerow([x, y, brightness])
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/software/obi/applet/open_beam_interface/__init__.py
+++ b/software/obi/applet/open_beam_interface/__init__.py
@@ -944,7 +944,7 @@ class CommandExecutor(wiring.Component):
         with m.FSM():
             with m.State("Imaging"):
                 m.d.comb += [
-                    self.img_stream.payload.eq(self.supersampler.adc_stream.payload.adc_code),
+                    self.img_stream.payload.eq(self.supersampler.adc_stream.payload.adc_code << 2),
                     self.img_stream.valid.eq(self.supersampler.adc_stream.valid),
                     self.supersampler.adc_stream.ready.eq(self.img_stream.ready),
                     self.output_mode.eq(output_mode) #input to Serializer

--- a/software/obi/macros/frame_buffer.py
+++ b/software/obi/macros/frame_buffer.py
@@ -123,13 +123,13 @@ class Frame:
         """
         Get underlying frame data as an array of type :class:`np.uint16`
         """
-        return np.left_shift(self.canvas, 2)
+        return self.canvas
 
     def as_uint8(self) -> np.ndarray:
         """
         Get underlying frame data as an array of type :class:`np.uint8`
         """
-        return np.right_shift(self.canvas, 6).astype(np.uint8)
+        return np.right_shift(self.canvas, 8).astype(np.uint8)
 
     def saveImage_tifffile(self, save_path, bit_depth_8=True, bit_depth_16=False,
                             scalebar_HFOV=None):


### PR DESCRIPTION
This restores usability to `OutputMode.EightBit`. 
I've also added an additional example script.

## Previous behavior

- Raw bytes from `OutputMode.SixteenBit`: MSB = 14
- Raw bytes from `OutputMode.EightBit`: MSB = 6. That's no good when you want 8 bits of data.

## New behavior
- Raw bytes from `OutputMode.SixteenBit`: MSB = 16
- Raw bytes from `OutputMode.EightBit`: MSB = 8