### PR TITLE
Update pinout format to match Glasgow

### DIFF
--- a/software/configs/fei_db.toml
+++ b/software/configs/fei_db.toml
@@ -3,13 +3,13 @@ manufacturer='FEI'
 model='DB'
 
 [beam.ion.pinout]
-scan_enable = [0,1]
-blank_enable = [2,3]
-blank = [-4, 5]
+scan_enable = "A0:1"
+blank_enable = "A2:3"
+blank = "#A4,A5"
 
 [beam.electron.pinout]
-blank = [6,7]
-scan_enable = [8,9]
+blank = "A6:7"
+scan_enable = "B0:1"
 
 [transforms]
 xflip = true

--- a/software/configs/fib_200.toml
+++ b/software/configs/fib_200.toml
@@ -4,9 +4,9 @@ model='FIB 200'
 
 
 [beam.ion.pinout]
-scan_enable = [0,1]
-blank_enable = [4,5]
-blank = [-2,3]
+scan_enable = "A0:1"
+blank_enable = "A4:4"
+blank = "A2#,A3"
 
 [transforms]
 yflip = true

--- a/software/configs/jeol_840_6300_6400.toml
+++ b/software/configs/jeol_840_6300_6400.toml
@@ -4,7 +4,7 @@ model='840,6300,6400'
 
 
 [beam.electron.pinout]
-scan_enable = [0]
+scan_enable = "A0"
 
 [transforms]
 yflip = true

--- a/software/configs/zeiss.toml
+++ b/software/configs/zeiss.toml
@@ -3,7 +3,7 @@ manufacturer='Zeiss'
 model='Sigma'
 
 [beam.electron.pinout]
-scan_enable = [0]
+scan_enable = "A0"
 
 
 

--- a/software/docs/source/config.md
+++ b/software/docs/source/config.md
@@ -34,18 +34,18 @@ When this signal is active, the microscope's blanking state is driven by the bla
 When this signal is active (and enabled by Blank Enable), the beam is in the blanked state. When this signal is inactive (and enabled by Blank Enable), the beam is in the unblanked state.
 
 ### Pin width and direction
-Beam IO signals can be assigned to any of the 16 Digital IO pins in Glasgow's main banks (Port A and Port B). Each signal can be assigned to up to two pins, and each pin can be configured as a pull up or pull down. The pinout must be described in the form of a list, with negative numbers corresponding to inverted pins. 
+Beam IO signals can be assigned to any of the 16 Digital IO pins in Glasgow's main banks (Port A and Port B). Each signal can be assigned to up to two pins, and each pin can be configured as a pull up or pull down. The pinout must be a string in the form of a [Glasgow pin argument](https://glasgow-embedded.org/latest/use/basic.html#inverting-pins), with each pin described by its port (A or B) and number and preceded by `#` if inverted. 
 Examples:
-     `blank = [1]`: Port A, Pin 1 will be high when blanking
-     `blank = [8,9]`: Port B, Pin 0 and 1 will be high when blanking
-     `blank = [-3,4]`: Port A, Pin 3 will be low and Pin 4 will be high when blanking.
+     `blank = "A1"`: Port A, Pin 1 will be high when blanking
+     `blank = "B0:1"`: Port B, Pin 0 and 1 will be high when blanking
+     `blank = "A3#,A4`: Port A, Pin 3 will be low and Pin 4 will be high when blanking.
 Note that Glasgow port pinouts are zero-indexed.
 
 ```
 [beam.electron.pinout]
-scan_enable = [1]
-blank_enable = [2,3]
-blank = [4, -5]
+scan_enable = "A1"
+blank_enable = "A2:3"
+blank = "A4,#A5"
 ```
 
 ### Magnification Calibration Data

--- a/software/obi/config/applet.py
+++ b/software/obi/config/applet.py
@@ -54,22 +54,15 @@ class OBIAppletArguments:
         if "beam" in config:
             beam_types = config["beam"]
             print(f"beam types: {[x for x in beam_types.keys()]}")
-            beam_prefixes = {"electron": "ebeam", "ion": "ibeam"}
             for beam, beam_config in beam_types.items():
                 if "pinout" in beam_config:
                     pinout = beam_config["pinout"]
                     for pin_name in pinout:
-                        pin_num = pinout.get(pin_name)
-                        pin_name = f"{beam_prefixes.get(beam)}_{pin_name.replace('-','_')}"
-                        pins = [GlasgowPin(port="A", number=num) if num >= 0 else GlasgowPin(port="A", number=abs(num), invert=True) for num in pin_num ]
-                        # print(pins)
+                        pin_str = pinout.get(pin_name)
+                        pin_name = f"{beam}_{pin_name.replace('-','_')}"
+                        pins = GlasgowPin.parse(pin_str)
                         setattr(self.args, pin_name, pins)
-                        if has_rich:
-                            for pin in pins:
-                                table.add_row(str(pin_name), str(pin), str(pin.invert))
-            if has_rich:
-                console = Console()
-                console.print(table)
+
         if "transforms" in config:
             transforms = config["transforms"]
             for transform, setting in transforms.items():

--- a/software/tests/config/test.toml
+++ b/software/tests/config/test.toml
@@ -1,12 +1,12 @@
 [beam.electron]
 [beam.electron.pinout]
-scan_enable = [0,1]
+scan_enable = "A0:1"
 
 
 [beam.ion]
 [beam.ion.pinout]
-blank_enable = [4, 5]
-blank = [-2, 3]
+blank_enable = "A4:5"
+blank = "A2#,A3"
 
 [transforms]
 yflip = true

--- a/software/tests/config/test_meta.py
+++ b/software/tests/config/test_meta.py
@@ -10,6 +10,6 @@ class ParseMetaTest(unittest.TestCase):
         self.assertIn("ion", s.beam_settings)
         pinout_e = s.beam_settings["electron"].pinout
         pinout_i = s.beam_settings["ion"].pinout
-        self.assertEqual(pinout_e.scan_enable, [0,1])
-        self.assertEqual(pinout_i.blank_enable, [4,5])
-        self.assertEqual(pinout_i.blank, [-2,3])
+        self.assertEqual(pinout_e.scan_enable, "A0:1")
+        self.assertEqual(pinout_i.blank_enable, "A4:5")
+        self.assertEqual(pinout_i.blank, "#A2,A3")


### PR DESCRIPTION
This is a breaking change - users will have to update their `microscope.toml` file to the new format. See [the Glasgow documentation](https://glasgow-embedded.org/latest/use/basic.html#inverting-pins) for details.

Example configuration files and documentation have also been updated.