### PR TITLE
Replacing configurable output modes

### DIFF
--- a/software/obi/applet/open_beam_interface/__init__.py
+++ b/software/obi/applet/open_beam_interface/__init__.py
@@ -52,7 +52,7 @@ class CommandExecutor(wiring.Component):
     blank_enable: Out(1, init=1)
 
     #Input to Serializer
-    output_mode: Out(2)
+    output_mode: Out(OutputMode)
 
 
     def __init__(self, *, out_only:bool=False, adc_latency=8, ext_delay_cyc=960000,
@@ -90,7 +90,7 @@ class CommandExecutor(wiring.Component):
         vector_stream = stream.Signature(DACStream).create()
 
         raster_mode = Signal()
-        output_mode = Signal(2)
+        output_mode = Signal(OutputMode)
         command = Signal.like(self.cmd_stream.payload)
         with m.If(raster_mode):
             wiring.connect(m, self.raster_scanner.dac_stream, self.supersampler.dac_stream)
@@ -223,6 +223,7 @@ class CommandExecutor(wiring.Component):
                         m.d.comb += [
                             self.raster_scanner.dwell_stream.valid.eq(1),
                             self.raster_scanner.dwell_stream.payload.dwell_time.eq(command.payload.raster_pixel.dwell_time),
+                            self.raster_scanner.dwell_stream.payload.output_en.eq(command.payload.raster_pixel.output_en),
                             self.raster_scanner.dwell_stream.payload.blank.eq(sync_blank)
                         ]
                         with m.If(self.raster_scanner.dwell_stream.ready):
@@ -234,6 +235,7 @@ class CommandExecutor(wiring.Component):
                         m.d.comb += [
                             self.raster_scanner.dwell_stream.valid.eq(1),
                             self.raster_scanner.dwell_stream.payload.dwell_time.eq(command.payload.raster_pixel_run.dwell_time),
+                            self.raster_scanner.dwell_stream.payload.output_en.eq(command.payload.raster_pixel_run.output_en),
                             self.raster_scanner.dwell_stream.payload.blank.eq(sync_blank)
                         ]
                         with m.If(self.raster_scanner.dwell_stream.ready):
@@ -280,8 +282,11 @@ class CommandExecutor(wiring.Component):
 
                     with m.Case(CmdType.VectorPixel, CmdType.VectorPixelMinDwell):
                         m.d.comb += vector_stream.valid.eq(1)
-                        m.d.comb += vector_stream.payload.blank.eq(sync_blank)
-                        m.d.comb += vector_stream.payload.delay.eq(inline_delay_counter)
+                        m.d.comb += [
+                            vector_stream.payload.blank.eq(sync_blank),
+                            vector_stream.payload.output_en.eq(command.payload.vector_pixel.output_en),
+                            vector_stream.payload.delay.eq(inline_delay_counter)
+                        ]
                         with m.If(vector_stream.ready):
                             m.d.sync += inline_delay_counter.eq(0)
                             m.d.comb += submit_pixel.eq(1)
@@ -334,18 +339,15 @@ class ImageSerializer(wiring.Component):
 
         with m.FSM():
             with m.State("High"):
-                with m.If(self.output_mode == OutputMode.NoOutput):
-                    m.d.comb += self.img_stream.ready.eq(1) #consume and destroy image stream
-                with m.Else():
-                    m.d.comb += self.usb_stream.payload.eq(self.img_stream.payload[8:16])
-                    m.d.comb += self.usb_stream.valid.eq(self.img_stream.valid)
-                    m.d.comb += self.img_stream.ready.eq(self.usb_stream.ready)
-                    with m.If(self.output_mode == OutputMode.SixteenBit):
-                        m.d.sync += low.eq(self.img_stream.payload[0:8])
-                        with m.If(self.usb_stream.ready & self.img_stream.valid):
-                            m.next = "Low"
-                    with m.If(self.output_mode == OutputMode.EightBit):
-                        m.next = "High"
+                m.d.comb += self.usb_stream.payload.eq(self.img_stream.payload[8:16])
+                m.d.comb += self.usb_stream.valid.eq(self.img_stream.valid)
+                m.d.comb += self.img_stream.ready.eq(self.usb_stream.ready)
+                with m.If(self.output_mode == OutputMode.SixteenBit):
+                    m.d.sync += low.eq(self.img_stream.payload[0:8])
+                    with m.If(self.usb_stream.ready & self.img_stream.valid):
+                        m.next = "Low"
+                with m.If(self.output_mode == OutputMode.EightBit):
+                    m.next = "High"
 
             with m.State("Low"):
                 m.d.comb += self.usb_stream.payload.eq(low)

--- a/software/obi/applet/open_beam_interface/modules/bus_controller.py
+++ b/software/obi/applet/open_beam_interface/modules/bus_controller.py
@@ -139,7 +139,8 @@ class BusController(wiring.Component):
                     # Transmit blanking state from input stream
                     m.d.comb += self.inline_blank.eq(self.dac_stream.payload.blank)
                     # Schedule ADC sample for these DAC codes to be output.
-                    m.d.sync += accept_sample.eq(Cat(1, accept_sample))
+                    with m.If(self.dac_stream.payload.output_en): 
+                        m.d.sync += accept_sample.eq(Cat(1, accept_sample))
                     # Carry over the flag for last sample [of averaging window] to the output.
                     m.d.sync += last_sample.eq(Cat(self.dac_stream.payload.last, last_sample))
                 with m.Else():

--- a/software/obi/applet/open_beam_interface/modules/raster_scanner.py
+++ b/software/obi/applet/open_beam_interface/modules/raster_scanner.py
@@ -2,7 +2,7 @@ from amaranth import *
 from amaranth.lib import data, stream, wiring
 from amaranth.lib.wiring import In, Out, flipped
 
-from obi.applet.open_beam_interface.modules.structs import RasterRegion, DACStream, DwellTime, BlankRequest
+from obi.applet.open_beam_interface.modules.structs import RasterRegion, DACStream, DwellTime, BlankRequest, OutputEnable
 
 class RasterScanner(wiring.Component):
     """
@@ -23,6 +23,7 @@ class RasterScanner(wiring.Component):
     dwell_stream: In(stream.Signature(data.StructLayout({
         "dwell_time": DwellTime,
         "blank": BlankRequest,
+        "output_en": OutputEnable
     })))
 
     abort: In(1)

--- a/software/obi/applet/open_beam_interface/modules/structs.py
+++ b/software/obi/applet/open_beam_interface/modules/structs.py
@@ -5,6 +5,8 @@ from amaranth.lib.wiring import In, Out, flipped
 
 from dataclasses import dataclass
 
+from obi.commands.structs import OutputEnable
+
 class BlankRequest(data.Struct):
     enable: 1
     request: 1
@@ -32,6 +34,7 @@ class DACStream(data.Struct):
     padding_x: 2
     dwell_time: 16
     blank: BlankRequest
+    output_en: OutputEnable
     delay: 3
 
 
@@ -41,7 +44,8 @@ class SuperDACStream(data.Struct):
     dac_y_code: 14
     padding_y: 2
     blank: BlankRequest
-    last:       1
+    output_en: OutputEnable
+    last: 1
     delay: 3
 
 class RasterRegion(data.Struct):

--- a/software/obi/commands/__init__.py
+++ b/software/obi/commands/__init__.py
@@ -46,20 +46,16 @@ class BaseCommand(metaclass = ABCMeta):
 
     async def recv_res(self, pixel_count, stream, output_mode:OutputMode):
         self._logger.debug(f"waiting to receive {pixel_count} pixels, {output_mode=}")
-        if output_mode == OutputMode.NoOutput:
-                await asyncio.sleep(0)
-                pass
-        else:
-            if output_mode == OutputMode.SixteenBit:
-                res = array.array('H', bytes(await stream.read(pixel_count * 2)))
-                if not BIG_ENDIAN:
-                    res.byteswap()
-                await asyncio.sleep(0)
-                return res
-            if output_mode == OutputMode.EightBit:
-                res = array.array('B', await stream.read(pixel_count))
-                await asyncio.sleep(0)
-                return res
+        if output_mode == OutputMode.SixteenBit:
+            res = array.array('H', bytes(await stream.read(pixel_count * 2)))
+            if not BIG_ENDIAN:
+                res.byteswap()
+            await asyncio.sleep(0)
+            return res
+        if output_mode == OutputMode.EightBit:
+            res = array.array('B', await stream.read(pixel_count))
+            await asyncio.sleep(0)
+            return res
 __all__ += ["BaseCommand"]
 
 from .low_level_commands import (SynchronizeCommand, AbortCommand, FlushCommand, ExternalCtrlCommand,

--- a/software/obi/commands/low_level_commands.py
+++ b/software/obi/commands/low_level_commands.py
@@ -1,4 +1,4 @@
-from .structs import BitLayout, ByteLayout, CmdType, OutputMode, BeamType, u14, u16, DwellTime, DACCodeRange
+from .structs import BitLayout, ByteLayout, CmdType, OutputMode, OutputEnable, BeamType, u14, u16, DwellTime, DACCodeRange
 from . import BaseCommand
 
 from amaranth import *
@@ -162,9 +162,10 @@ class RasterPixelCommand(LowLevelCommand):
     One pixel dwell value. The position at which this pixel is executed
     depends on the current :class:`RasterRegionCommand`. 
     '''
+    bitlayout = BitLayout({"output_en": OutputEnable})
     bytelayout = ByteLayout({"dwell_time" : 2})
-    def __init__(self, *, dwell_time:DwellTime):
-        super().__init__(dwell_time=dwell_time)
+    def __init__(self, dwell_time:DwellTime, output_en: OutputEnable=True):
+        super().__init__(output_en=output_en, dwell_time=dwell_time)
 
 class ArrayCommand(LowLevelCommand):
     bitlayout = BitLayout({"cmdtype": CmdType})
@@ -183,9 +184,10 @@ class RasterPixelRunCommand(LowLevelCommand):
     The position at which these pixels are executed
     depends on the current :class:`RasterRegionCommand`. 
     '''
+    bitlayout = BitLayout({"output_en": OutputEnable})
     bytelayout = ByteLayout({"length": 2, "dwell_time" : 2})
-    def __init__(self, length: u16, dwell_time: DwellTime):
-        super().__init__(length=length, dwell_time=dwell_time)
+    def __init__(self, length: u16, dwell_time: DwellTime, output_en: OutputEnable=True):
+        super().__init__(output_en=output_en, length=length, dwell_time=dwell_time)
 
 class RasterPixelFreeRunCommand(LowLevelCommand):
     '''
@@ -201,9 +203,10 @@ class VectorPixelCommand(LowLevelCommand):
     '''
     Sets DAC output to the coordinate X, Y for the specified dwell time.
     '''
+    bitlayout = BitLayout({"output_en": OutputEnable})
     bytelayout = ByteLayout({"x_coord": 2, "y_coord": 2, "dwell_time": 2})
-    def __init__(self, x_coord:u14, y_coord:u14, dwell_time:u16):
-        super().__init__(x_coord=x_coord, y_coord=y_coord, dwell_time=dwell_time)
+    def __init__(self, x_coord:u14, y_coord:u14, dwell_time:u16, output_en: OutputEnable=True):
+        super().__init__(output_en=output_en, x_coord=x_coord, y_coord=y_coord, dwell_time=dwell_time)
     def pack(self):
         if vars(self)["dwell_time"] <= 1:
             return VectorPixelMinDwellCommand(**vars(self)).pack()
@@ -220,6 +223,7 @@ class VectorPixelCommand(LowLevelCommand):
         return await self.recv_res(1, stream, output_mode)
         
 class VectorPixelMinDwellCommand(LowLevelCommand):
+    bitlayout = BitLayout({"output_en": OutputEnable})
     bytelayout = ByteLayout({"dac_stream": {"x_coord": 2, "y_coord": 2}})
 
 all_commands = [SynchronizeCommand, 

--- a/software/obi/commands/structs.py
+++ b/software/obi/commands/structs.py
@@ -128,10 +128,13 @@ class ByteLayout(PayloadLayout):
 
 ##### start commands
 
-class OutputMode(enum.IntEnum, shape = 2):
+class OutputMode(enum.IntEnum, shape = 1):
     SixteenBit          = 0
     EightBit            = 1
-    NoOutput            = 2
+
+class OutputEnable(enum.IntEnum, shape = 1):
+    Enabled             = 0
+    Disabled            = 1
 
 class BeamType(enum.IntEnum, shape = 2):
     NoBeam              = 0

--- a/software/obi/macros/raster.py
+++ b/software/obi/macros/raster.py
@@ -35,11 +35,16 @@ class RasterScanCommand(BaseCommand):
 
         def append_command(pixel_count):
             while pixel_count > 65536:
-                cmd = RasterPixelRunCommand(dwell_time = self._dwell, length=65535)
+                cmd = RasterPixelRunCommand(dwell_time = self._dwell, length=65535, output_en=True)
                 commands.extend(bytes(cmd))
                 pixel_count -= 65536
-            cmd = RasterPixelRunCommand(dwell_time = self._dwell, length=pixel_count-1)
+            cmd = RasterPixelRunCommand(dwell_time = self._dwell, length=pixel_count-1, output_en=True)
             commands.extend(bytes(cmd))
+
+        def fly_back():
+            cmd = VectorPixelCommand(output_en=False, x_coord=self._x_range.start, y_coord=self._y_range.start, dwell_time=1)
+            commands.extend(bytes(cmd))
+
 
         pixel_count = 0
         total_dwell = 0
@@ -59,6 +64,9 @@ class RasterScanCommand(BaseCommand):
         if pixel_count > 0:
             append_command(pixel_count)
             yield(commands, pixel_count)
+        
+        fly_back()
+        yield(commands,0)
 
     @BaseCommand.log_transfer
     async def transfer(self, stream, *, latency:int=65536*65536):
@@ -101,8 +109,6 @@ class RasterScanCommand(BaseCommand):
                     break
             self._logger.debug(f"recver: tokens={tokens}")
             yield await self.recv_res(pixel_count, stream, self._output_mode)
-        ## fly back
-        # await VectorPixelCommand(x_coord=self._x_range.start, y_coord=self._y_range.start, dwell_time=1).transfer(stream)
 
 
 


### PR DESCRIPTION
## Prior work
Currently, OBI can be set to one of three [output modes](https://github.com/nanographs/Open-Beam-Interface/blob/676a96e9dc28feac6720a50a28685237e3db0893/software/obi/commands/structs.py#L131): Sixteen bit, Eight bit, or None. 

It would be useful to instead be able to enable or disable output on a per-pixel basis. For example, between subsequent raster frames, one could use vector commands to define the beam flyback path.

## Proposed Change
Currently there are 4 bits of Free Real Estate in the header of every pixel command. One of those could be used to enable or disable whether data is returned for that pixel.

## Benefits
This change does not solve #43, but provides another tool for handling flyback distortion. 

## Drawbacks
This change would be somewhat incompatible with my vision for [ArrayCommand](https://github.com/nanographs/Open-Beam-Interface/blob/562869fffad6c45aea29624e1400a3e10a61227f/software/obi/commands/low_level_commands.py#L169), but ArrayCommand hasn't been used to build anything yet anyway.

